### PR TITLE
chore: update deprecated plugin to new package

### DIFF
--- a/ci/release/dry_run.sh
+++ b/ci/release/dry_run.sh
@@ -35,7 +35,7 @@ nix develop -c npx --yes \
   -p "@semantic-release/changelog" \
   -p "@semantic-release/exec" \
   -p "@semantic-release/git" \
-  -p "@google/semantic-release-replace-plugin" \
+  -p "semantic-release-replace-plugin" \
   -p "conventional-changelog-conventionalcommits" \
   semantic-release \
   --ci \

--- a/ci/release/run.sh
+++ b/ci/release/run.sh
@@ -10,6 +10,6 @@ nix develop -c npx --yes \
   -p "@semantic-release/github" \
   -p "@semantic-release/exec" \
   -p "@semantic-release/git" \
-  -p "@google/semantic-release-replace-plugin" \
+  -p "semantic-release-replace-plugin" \
   -p "conventional-changelog-conventionalcommits" \
   semantic-release --ci


### PR DESCRIPTION
This is a PR to update the semantic-release-replace-plugin to the [new package](https://www.npmjs.com/package/semantic-release-replace-plugin) from the [deprecated version](https://www.npmjs.com/package/@google/semantic-release-replace-plugin).